### PR TITLE
Update to support SDWebImage 5.5's new `thumbnailPixelSize` option

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "SDWebImage/SDWebImage" ~> 5.0
+github "SDWebImage/SDWebImage" ~> 5.5
 github "SVGKit/SVGKit" >= 2.1

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,9 +2,9 @@ PODS:
   - CocoaLumberjack (3.6.0):
     - CocoaLumberjack/Core (= 3.6.0)
   - CocoaLumberjack/Core (3.6.0)
-  - SDWebImage/Core (5.3.1)
+  - SDWebImage/Core (5.5.2)
   - SDWebImageSVGKitPlugin (1.0.0):
-    - SDWebImage/Core (~> 5.0)
+    - SDWebImage/Core (~> 5.5)
     - SVGKit (>= 2.1)
   - SVGKit (2.1.0):
     - CocoaLumberjack (~> 3.0)
@@ -27,13 +27,13 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   SVGKit:
-    :commit: 39dd210fd47e3195f57f914354ffd2d0b4b8ff1c
+    :commit: 8560ef56bd61e34d5cd8d9739954f9765e3ac794
     :git: https://github.com/SVGKit/SVGKit.git
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 78b0c238666f4f58db069738ec176f4519557516
-  SDWebImage: 7137d57385fb632129838c1e6ab9528a22c666cc
-  SDWebImageSVGKitPlugin: ec8a6a4492d1dc40f5f9fa1dee4acca07f93ad15
+  SDWebImage: 4d5c027c935438f341ed33dbac53ff9f479922ca
+  SDWebImageSVGKitPlugin: 02e1f98cf9ed0814788bba781fad59ac4185dfc4
   SVGKit: 8a2fc74258bdb2abb54d3b65f3dd68b0277a9c4d
 
 PODFILE CHECKSUM: 91804dc9be5d336ef696711e8704688dfe2f0a2a

--- a/Example/SDWebImageSVGKitPlugin/SDViewController.m
+++ b/Example/SDWebImageSVGKitPlugin/SDViewController.m
@@ -61,7 +61,7 @@
         }
     }];
     // For `UIImageView`, you can specify a desired SVG size instead of original SVG viewport (which may be small)
-    [imageView3 sd_setImageWithURL:svgURL3 placeholderImage:nil options:SDWebImageRetryFailed context:@{SDWebImageContextSVGKImageSize : @(CGSizeMake(100, 100))} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+    [imageView3 sd_setImageWithURL:svgURL3 placeholderImage:nil options:SDWebImageRetryFailed context:@{SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(100, 100))} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
             NSLog(@"UIImageView SVG load success");
         }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 ## What's for
 SDWebImageSVGKitPlugin is a SVG coder plugin for [SDWebImage](https://github.com/rs/SDWebImage/) framework, which provide the image loading support for [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) using [SVGKit](https://github.com/SVGKit/SVGKit) SVG engine.
 
+Note: iOS 13+/macOS 10.15+ supports native SVG rendering (called [Symbol Image](https://developer.apple.com/documentation/uikit/uiimage/configuring_and_displaying_symbol_images_in_your_ui/)), with system framework to load SVG. Check [SDWebImageSVGCoder](https://github.com/SDWebImage/SDWebImageSVGCoder) for more information.
+
 ## Example
 
 To run the example project, clone the repo, and run `pod install` from the Example directory first.
@@ -18,9 +20,9 @@ You can modify the code or use some other SVG files to check the compatibility.
 
 ## Requirements
 
-+ iOS 8
-+ tvOS 9
-+ macOS 10.10
++ iOS 8+
++ tvOS 9+
++ macOS 10.10+
 
 ## Installation
 
@@ -53,7 +55,7 @@ github "SDWebImage/SDWebImageSVGKitPlugin"
 
 To use SVG coder, you should firstly add the `SDImageSVGKCoder` to the coders manager. Then you can call the View Category method to start load SVG images.
 
-Because SVG is a [vector image](https://en.wikipedia.org/wiki/Vector_graphics) format, which means it does not have a fixed bitmap size. However, `UIImage` or `CGImage` are all [bitmap image](https://en.wikipedia.org/wiki/Raster_graphics). For `UIImageView`, we will only parse SVG with a fixed image size (from the SVG viewPort information). But we also support you to specify a desired size during image loading using `SDWebImageContextSVGKImageSize` context option. And you can specify whether or not to keep aspect ratio during scale using `SDWebImageContextSVGKImagePreserveAspectRatio` context option.
+Because SVG is a [vector image](https://en.wikipedia.org/wiki/Vector_graphics) format, which means it does not have a fixed bitmap size. However, `UIImage` or `CGImage` are all [bitmap image](https://en.wikipedia.org/wiki/Raster_graphics). For `UIImageView`, we will only parse SVG with a fixed image size (from the SVG viewPort information). But we also support you to specify a desired size during image loading using `SDWebImageContextThumbnailPixelSize` context option. And you can specify whether or not to keep aspect ratio during scale using `SDWebImageContextImagePreserveAspectRatio` context option.
 
 + Objective-C
 
@@ -63,7 +65,7 @@ SDImageSVGKCoder *svgCoder = [SDImageSVGKCoder sharedCoder];
 UIImageView *imageView;
 // this arg is optional, if don't provide, use the viewport size instead
 CGSize svgImageSize = CGSizeMake(100, 100);
-[imageView sd_setImageWithURL:url placeholderImage:nil options:0 context:@{SDWebImageContextSVGKImageSize : @(svgImageSize)];
+[imageView sd_setImageWithURL:url placeholderImage:nil options:0 context:@{SDWebImageContextThumbnailPixelSize : @(svgImageSize)];
 ```
 
 + Swift
@@ -75,7 +77,7 @@ let imageView: UIImageView
 imageView.sd_setImage(with: url)
 // this arg is optional, if don't provide, use the viewport size instead
 let svgImageSize = CGSize(width: 100, height: 100)
-imageView.sd_setImage(with: url, placeholderImage: nil, options: [], context: [.svgkImageSize : svgImageSize])
+imageView.sd_setImage(with: url, placeholderImage: nil, options: [], context: [.imageThumbnailPixelSize : svgImageSize])
 ```
 
 ### Use SVGKImageView (render SVG as vector image)
@@ -120,7 +122,7 @@ NSData *imageData = [image sd_imageDataAsFormat:SDImageFormatSVG];
 + Swift
 
 ```swift
-let image; // Image generated from SDWebImage framework, actually a `SDSVGKImage` instance.
+let image: UIImage // Image generated from SDWebImage framework, actually a `SDSVGKImage` instance.
 let imageData = image.sd_imageData(as: .SVG)
 ```
 

--- a/SDWebImageSVGKitPlugin.podspec
+++ b/SDWebImageSVGKitPlugin.podspec
@@ -33,6 +33,6 @@ TODO: Add long description of the pod here.
   s.source_files = 'SDWebImageSVGKitPlugin/Classes/**/*', 'SDWebImageSVGKitPlugin/Module/SDWebImageSVGKitPlugin.h'
   s.module_map = 'SDWebImageSVGKitPlugin/Module/SDWebImageSVGKitPlugin.modulemap'
   
-  s.dependency 'SDWebImage/Core', '~> 5.0'
+  s.dependency 'SDWebImage/Core', '~> 5.5'
   s.dependency 'SVGKit', '>= 2.1'
 end

--- a/SDWebImageSVGKitPlugin/Classes/SDImageSVGKCoder.m
+++ b/SDWebImageSVGKitPlugin/Classes/SDImageSVGKCoder.m
@@ -41,6 +41,9 @@
     
     CGSize imageSize = CGSizeZero;
     BOOL preserveAspectRatio = YES;
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     // Parse args
     SDWebImageContext *context = options[SDImageCoderWebImageContext];
     if (context[SDWebImageContextSVGKImageSize]) {
@@ -50,10 +53,20 @@
 #else
         imageSize = sizeValue.sizeValue;
 #endif
+    } else if (options[SDImageCoderDecodeThumbnailPixelSize]) {
+        NSValue *sizeValue = options[SDImageCoderDecodeThumbnailPixelSize];
+#if SD_UIKIT
+        imageSize = sizeValue.CGSizeValue;
+#else
+        imageSize = sizeValue.sizeValue;
+#endif
     }
     if (context[SDWebImageContextSVGKImagePreserveAspectRatio]) {
         preserveAspectRatio = [context[SDWebImageContextSVGKImagePreserveAspectRatio] boolValue];
+    } else if (options[SDImageCoderDecodePreserveAspectRatio]) {
+        preserveAspectRatio = [options[SDImageCoderDecodePreserveAspectRatio] boolValue];
     }
+#pragma clang diagnostic pop
     
     if (!CGSizeEqualToSize(imageSize, CGSizeZero)) {
         if (preserveAspectRatio) {

--- a/SDWebImageSVGKitPlugin/Classes/SDSVGKImage.m
+++ b/SDWebImageSVGKitPlugin/Classes/SDSVGKImage.m
@@ -61,18 +61,29 @@
     if (!svgImage) {
         return nil;
     }
+    CGSize imageSize = CGSizeZero;
+    
     // Check specified image size
     SDWebImageContext *context = options[SDImageCoderWebImageContext];
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (context[SDWebImageContextSVGKImageSize]) {
         NSValue *sizeValue = context[SDWebImageContextSVGKImageSize];
 #if SD_UIKIT
-        CGSize imageSize = sizeValue.CGSizeValue;
+        imageSize = sizeValue.CGSizeValue;
 #else
-        CGSize imageSize = sizeValue.sizeValue;
+        imageSize = sizeValue.sizeValue;
 #endif
-        if (!CGSizeEqualToSize(imageSize, CGSizeZero)) {
-            svgImage.size = imageSize;
-        }
+    } else if (options[SDImageCoderDecodeThumbnailPixelSize]) {
+        NSValue *sizeValue = options[SDImageCoderDecodeThumbnailPixelSize];
+#if SD_UIKIT
+        imageSize = sizeValue.CGSizeValue;
+#else
+        imageSize = sizeValue.sizeValue;
+#endif
+    }
+    if (!CGSizeEqualToSize(imageSize, CGSizeZero)) {
+        svgImage.size = imageSize;
     }
     return [self initWithSVGKImage:svgImage];
 }

--- a/SDWebImageSVGKitPlugin/Classes/SDWebImageSVGKitDefine.h
+++ b/SDWebImageSVGKitPlugin/Classes/SDWebImageSVGKitDefine.h
@@ -25,10 +25,10 @@ FOUNDATION_EXPORT void SDAdjustSVGContentMode(SVGKImage * __nonnull image, UIVie
  A CGSize raw value which specify the desired SVG image size during image loading. Because vector image like SVG format, may not contains a fixed size, or you want to get a larger size bitmap representation UIImage. (NSValue)
  If you don't provide this value, use viewBox size of SVG for default value;
  */
-FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextSVGKImageSize;
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextSVGKImageSize __attribute__((deprecated("Use the new context option (for WebCache category), or coder option (for SDImageCoder protocol) instead", "SDWebImageContextImageThumbnailPixelSize")));
 
 /**
  A BOOL value which specify the whether SVG image should keep aspect ratio during image loading. Because when you specify image size via `SDWebImageContextSVGKImageSize`, we need to know whether to keep aspect ratio or not when image size aspect ratio is not equal to SVG viewBox size aspect ratio. (NSNumber)
  If you don't provide this value, use YES for default value.
  */
-FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextSVGKImagePreserveAspectRatio;
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextSVGKImagePreserveAspectRatio __attribute__((deprecated("Use the new context option (for WebCache category), or coder option (for SDImageCoder protocol) instead", "SDWebImageContextImagePreserveAspectRatio")));


### PR DESCRIPTION
Deprecated the current SVGK prefixed options:

+ SDWebImageContextSVGKImageSize
+ SDWebImageContextSVGKImagePreserveAspectRatio